### PR TITLE
Fix typo in math.md: Wrong example macro

### DIFF
--- a/docs/math.md
+++ b/docs/math.md
@@ -221,7 +221,7 @@ The `math` macros are parsed as `yaml` in the frontmatter and can easily be shar
 When using the YAML syntax for the `math` macros, use **single quotes** around the strings. The single quote yaml syntax means you do not have to text-escape the strings, otherwise backslashes `\f`, `\n`, `\b`, `\r`, `\t` and other symbols have to be escaped which is difficult to remember and leads to all sorts of strange errors.
 ```
 
-The `key` is the command that you are defining, in the demo above `\dobs` or `\dpred`, the command should include the `\`. The value of the entry should be the macro definition, if the definition contains `#1` then there will be one required argument for the macro that should be supplied in braces when you use it (e.g. `\dpred{m}`). The macros can be nested as in the example where `\dobs{\mref}` uses two macros.
+The `key` is the command that you are defining, in the demo above `\dobs` or `\dpred`, the command should include the `\`. The value of the entry should be the macro definition, if the definition contains `#1` then there will be one required argument for the macro that should be supplied in braces when you use it (e.g. `\dpred{m}`). The macros can be nested as in the example where `\dpred{\mref}` uses two macros.
 
 In the macro in the example above, `\mathbf{d}_\text{pred}\left( #1 \right)`, the `#1` is the first and only required argument, and is placed in between left and right brackets. The numbering for arguments starts at one, and other arguments can be added with `#2`, `#3`, etc. and then input in a command using `\command{arg1}{arg2}`.
 


### PR DESCRIPTION
The text says
> The macros can be nested as in the example where `\dobs{\mref}` uses two macros.

which is incorrect, because the `\dobs` macro in the example takes no argument. Rather the text in the example box just above uses `\dpred{\mref}`.